### PR TITLE
Active model nested in hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,32 @@ copy = Email.new_from_portable_hash(gid)
 signed_copy = Email.new_from_portable_hash(sgid)
 ```
 
+### ActiveModel Nested in Hash
+
+UniversalID can also handle instances of `ActiveModel` that are nested inside a hash:
+
+```rb
+@campaign = Campaign.create(name: "Example Campaign", description: "Example Description", trigger: "Example Trigger")
+@hash = UniversalID::PortableHash.new({name: "Example", list: [1,2,3], object: {nested: true}, campaign: @campaign})
+
+gid_param = portable.to_gid_param #..... Z2lkOi8vVW5pdmVyc2FsSUQvVW5pdmVyc2FsSUQ6OlBvcnRhYmxlSGFzaC9lTnFyVnNwTHpFMVZzbEp5clVqTUxj...
+sgid_param = portable.to_sgid_param #... BAh7CEkiCGdpZAY6BkVUSSIBg2dpZDovL1VuaXZlcnNhbElEL1VuaXZlcnNhbElEOjpQb3J0YWJsZUhhc2gvZU5x...
+
+
+UniversalID::PortableHash.parse_gid(gid_param).find
+{name: "Example", list: [1,2,3], object: {nested: true}, campaign: <Campaign id: ...>}}
+
+
+UniversalID::PortableHash.parse_gid(sgid_param).find
+{"name"=>"Example", "list"=>[1, 2, 3], "object"=>{"nested"=>true, campaign: <Campaign id: ...>}}
+```
+
+**Note**: To use this feature, you have to engage our custom GlobalID Locator:
+
+```rb
+GlobalID::Locator.use :my_app, UniversalID::Locator.new
+```
+
 ### Running Tests, Benchmarks, and the Demo
 
 ```

--- a/lib/universal_id.rb
+++ b/lib/universal_id.rb
@@ -11,3 +11,6 @@ require_relative "universal_id/config"
 require_relative "universal_id/portable"
 require_relative "universal_id/portable_hash"
 require_relative "universal_id/active_model_serializer"
+require_relative "universal_id/locator"
+
+GID_PARAM_REGEX = /\Agid:\/\/.*\z/

--- a/lib/universal_id/locator.rb
+++ b/lib/universal_id/locator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class UniversalID::Locator < GlobalID::Locator::BaseLocator
+  def locate(gid, options = {})
+    located_hash = super
+    deep_hydrate(located_hash)
+  end
+
+  private
+
+  def deep_hydrate(value)
+    case value
+    when Array
+      value.map(&:deep_hydrate) if value.is_a?(Array)
+    when Hash
+      value.deep_transform_values { |v| possible_gid_string?(v) ? GlobalID::Locator.locate(v) : v }
+    else
+      value
+    end
+  end
+
+  def possible_gid_string?(value)
+    return false unless value.is_a?(String)
+    GID_PARAM_REGEX.match? value
+  end
+end

--- a/lib/universal_id/portable_hash.rb
+++ b/lib/universal_id/portable_hash.rb
@@ -32,7 +32,8 @@ class UniversalID::PortableHash < Hash
       value = case value
       when Hash then deep_transform(value, options)
       when Array then value.map { |val| transform(val, options: options) }
-      else value
+      else
+        implements_gid?(value) ? value.to_gid.to_s : value
       end
 
       if block_given?
@@ -40,6 +41,15 @@ class UniversalID::PortableHash < Hash
       end
 
       value
+    end
+
+    def implements_gid?(value)
+      value.respond_to?(:to_gid_param) && value.try(:persisted?)
+    end
+
+    def possible_gid_string?(value)
+      return false unless value.is_a?(String)
+      GID_PARAM_REGEX.match? value
     end
   end
 

--- a/test/models.rb
+++ b/test/models.rb
@@ -6,6 +6,7 @@ require "active_record"
 GlobalID.app = "UniversalID"
 SignedGlobalID.app = "UniversalID"
 SignedGlobalID.verifier = GlobalID::Verifier.new("UniversalID")
+GlobalID::Locator.use "UniversalID", UniversalID::Locator.new
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 

--- a/test/universal_id/active_model_in_portable_hash_test.rb
+++ b/test/universal_id/active_model_in_portable_hash_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class UniversalID::ActiveModelInPortableHashTest < ActiveSupport::TestCase
+  def setup
+    @campaign = Campaign.create!(name: "Example Campaign", description: "Example Description", trigger: "Example Trigger")
+    @hash = UniversalID::PortableHash.new(
+      test: true,
+      example: "value",
+      other: nil,
+      nested: {
+        keep: "keep",
+        remove: "remove"
+      },
+      campaign: @campaign,
+      portable_hash_options: {except: %w[remove]} # combines with config
+    )
+  end
+
+  def teardown
+    @campaign.destroy
+  end
+
+  def test_find
+    assert_equal @hash, UniversalID::PortableHash.find(@hash.id)
+  end
+
+  def test_to_gid
+    gid = @hash.to_gid
+
+    expected = {"test" => true, "example" => "value", "nested" => {"keep" => "keep"}, "campaign" => @campaign}
+
+    assert_equal expected, gid.find
+  end
+
+  def test_to_sgid
+    sgid = @hash.to_sgid
+
+    expected = {"test" => true, "example" => "value", "nested" => {"keep" => "keep"}, "campaign" => @campaign}
+
+    assert_equal expected, sgid.find
+  end
+end


### PR DESCRIPTION
Introduces the capability to (de)hydrate ActiveModels (or anything GID-able) into `PortableHash`

This necessitates a custom locator to work - README note added.

Note that there's some duplication here regarding `implements_sgid?`, but I think it's too early and far fetched to extract this.