### PR TITLE
Allow arbitrary primary key columns

### DIFF
--- a/contrib/active_record/active_record_unpacker.rb
+++ b/contrib/active_record/active_record_unpacker.rb
@@ -17,7 +17,7 @@ class UniversalID::Contrib::ActiveRecordUnpacker
       return nil unless klass
 
       record = if attributes[klass.primary_key]
-        klass.find_by(id: attributes[klass.primary_key])
+        klass.find_by(klass.primary_key => attributes[klass.primary_key])
       else
         klass.new
       end


### PR DESCRIPTION
As it happens, my (legacy) app that I'm testing this on uses a different primary key column than `id`... 🙃 